### PR TITLE
fixes vanishing background in flappy bird sample

### DIFF
--- a/samples/FlappyBird/app/game_scene.rb
+++ b/samples/FlappyBird/app/game_scene.rb
@@ -106,7 +106,7 @@ class GameScene < MG::Scene
         pos2.x = pos1.x + width - 5
       elsif pos3.x <= -(width / 2.0)
         pos3.x = pos2.x + width - 5
-      elsif pos3.x <= -(width / 2.0)
+      elsif pos4.x <= -(width / 2.0)
         pos4.x = pos3.x + width - 5
       end
       sprite1.position = pos1


### PR DESCRIPTION
The flappy bird motion-game sample has a bug where the `ground sprite` and `background/sky sprite` vanish after playing the game for a while. like so:

<img width="389" alt="screen shot 2016-04-26 at 11 18 03 am" src="https://cloud.githubusercontent.com/assets/3013328/14823897/1ffe6b72-0ba2-11e6-9bc5-e007e0728931.png">

This small change fixes this error.