### PR TITLE
Implement sprite_new_with_image to create a Sprite from raw image data

### DIFF
--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -54,6 +54,27 @@ sprite_new(VALUE rcv, SEL sel, VALUE name)
     return rb_class_wrap_new((void *)sprite, rcv);
 }
 
+/// @method #new_with_image(data, len)
+/// Creates a sprite from +data+ stream buffer image data and +len+ length
+/// @param data [String] image data stream buffer
+/// @param len [Integer] data length
+/// @return [Sprite]
+
+static VALUE
+sprite_new_with_image(VALUE rcv, SEL sel, VALUE data, VALUE len)
+{
+  cocos2d::Sprite *sprite = NULL;
+  cocos2d::Texture2D *texture = new cocos2d::Texture2D();
+  cocos2d::Image *image = new cocos2d::Image();
+
+  image->initWithImageData((unsigned char *)RSTRING_PTR(StringValue(data)), len);
+  texture->initWithImage(image);
+  sprite = cocos2d::Sprite::createWithTexture(texture);
+
+  assert(sprite != NULL); // TODO raise exception
+  return rb_class_wrap_new((void *)sprite, rcv);
+}
+
 /// @group Actions
 
 static VALUE
@@ -181,7 +202,7 @@ need_physics(VALUE rcv)
 {
     auto physics = SPRITE(rcv)->getPhysicsBody();
     if (physics == NULL) {
-	rb_raise(rb_eRuntimeError, "receiver does not have a physics body"); 
+	rb_raise(rb_eRuntimeError, "receiver does not have a physics body");
     }
     return physics;
 }
@@ -405,6 +426,7 @@ Init_Sprite(void)
 
     rb_define_singleton_method(rb_cSprite, "load", sprite_load, 1);
     rb_define_singleton_method(rb_cSprite, "new", sprite_new, 1);
+    rb_define_singleton_method(rb_cSprite, "new_with_image", sprite_new_with_image, 2);
     rb_define_method(rb_cSprite, "move_by", sprite_move_by, 2);
     rb_define_method(rb_cSprite, "move_to", sprite_move_to, 2);
     rb_define_method(rb_cSprite, "blink", sprite_blink, 2);


### PR DESCRIPTION
This creates a convenience singleton method on Sprite to create an `Image` from raw image data, a `Texture` from that `Image`, and finally a `Sprite` using `createWithTexture`.

Ideally the `Image` and `Texture` classes would be fully exposed to Ruby, but this is beyond my capabilities at the moment.

Example usage (based on motion-flow with motion-game example here https://github.com/andrewhavens/motion-game-with-flow-example ):
```ruby
# Inside an MG::Scene
Net.get("http://www.rubymotion.com/img/rubymotion-logo.png") do |response|
  dat = response.body.to_data.to_s
  img = MG::Sprite.new_with_image(dat, dat.length)
  add img
end
```

The above example won't work on Android for two reasons:

1. `.to_data` is unavailable
2. A hard coded string in Ruby is interpreted differently somehow by the time it reaches this C++ code, I believe because Java strings are UTF-16 by default, but I am not certain.