### PR TITLE
Adds more methods

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -62,6 +62,15 @@ touch_location(VALUE rcv, SEL sel)
     return rb_ccvec2_to_obj(TOUCH(rcv)->getLocation());
 }
 
+/// @property-readonly #start_location
+/// @return [Point] the start_location of the touch event.
+
+static VALUE
+touch_start_location(VALUE rcv, SEL sel)
+{
+    return rb_ccvec2_to_obj(TOUCH(rcv)->getStartLocation());
+}
+
 extern "C"
 void
 Init_Events(void)
@@ -78,4 +87,5 @@ Init_Events(void)
     rb_cTouch = rb_define_class_under(rb_mEvents, "Touch", rb_cObject);
 
     rb_define_method(rb_cTouch, "location", touch_location, 0);
+    rb_define_method(rb_cTouch, "start_location", touch_start_location, 0);
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -135,6 +135,16 @@ point_distance(VALUE rcv, SEL sel, VALUE obj)
     return DBL2NUM(VEC2(rcv)->getDistance(rb_any_to_ccvec2(obj)));
 }
 
+/// @method #angle
+/// Calculates the angle in radians between this vector and the x-axis.
+/// @return [Float] the angle.
+
+static VALUE
+point_angle(VALUE rcv, SEL sel)
+{
+    return DBL2NUM(VEC2(rcv)->getAngle());
+}
+
 static VALUE
 point_inspect(VALUE rcv, SEL sel)
 {
@@ -473,6 +483,7 @@ Init_Types(void)
     rb_define_method(rb_cPoint, "+", point_plus, 1);
     rb_define_method(rb_cPoint, "-", point_minus, 1);
     rb_define_method(rb_cPoint, "distance", point_distance, 1);
+    rb_define_method(rb_cPoint, "angle", point_angle, 0);
     rb_define_method(rb_cPoint, "inspect", point_inspect, 0);
 
     rb_cSize = rb_define_class_under(rb_mMC, "Size", rb_cObject);


### PR DESCRIPTION
Adds `angle` to `Point`.
Example: `MG::Point.new(5,5).angle`

Adds `start_location` to `TouchEvent`
Example `on_touch_end { |event| puts event.start_location, event.location`.
`event.start_location` contains the coordinate where the touch startet.
`event.location` contains the coordinate where the touch ended.
Can be used for SwipeGesture.