### PR TITLE
Adds ability to create a MenuItemFont with Menu

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -16,7 +16,7 @@ menu_alloc(VALUE rcv, SEL sel)
 
 /// @method #align_items_vertically(padding=null)
 /// aligns menu items vertically with padding
-/// (call after adding items via image_item)
+/// (call after adding items via image_item or font_item)
 /// @param padding [Float] the amount of padding between the items.
 /// @return [self] the receiver.
 static VALUE
@@ -37,7 +37,7 @@ menu_align_items_vertically(VALUE rcv, SEL sel, int argc, VALUE *argv)
 
 /// @method #align_items_horizontally(padding=null)
 /// aligns menu items horizontally with padding
-/// (call after adding items via image_item)
+/// (call after adding items via image_item or font_item)
 /// @param padding [Float] the amount of padding between the items.
 /// @return [self] the receiver.
 static VALUE
@@ -102,6 +102,31 @@ menu_image_item(VALUE rcv, SEL sel, VALUE normal_image, VALUE selected_image)
     return rcv;
 }
 
+/// @method #font_item(name)
+/// Create a menu item with a label.
+/// @param name [String] label name.
+/// @yield The methods to call when tapped menu.
+/// @return [self] the receiver.
+
+static VALUE
+menu_font_item(VALUE rcv, SEL sel, VALUE label_name)
+{
+    VALUE block = rb_current_block();
+    if (block == Qnil) {
+	rb_raise(rb_eArgError, "block not given");
+    }
+    block = rb_retain(block); // FIXME need release...
+
+    cocos2d::MenuItemFont *item = cocos2d::MenuItemFont::create(
+	RSTRING_PTR(StringValue(label_name)),
+	[block](cocos2d::Ref *sender) {
+	    rb_block_call(block, 0, NULL);
+	});
+
+    MENU(rcv)->addChild(item);
+    return rcv;
+}
+
 extern "C"
 void
 Init_Menu(void)
@@ -113,6 +138,7 @@ Init_Menu(void)
     rb_define_method(rb_cMenu, "enabled?", menu_enabled, 0);
     rb_define_method(rb_cMenu, "enabled=", menu_enabled_set, 1);
     rb_define_method(rb_cMenu, "image_item", menu_image_item, 2);
+    rb_define_method(rb_cMenu, "font_item", menu_font_item, 1);
     rb_define_method(rb_cMenu, "align_items_horizontally", menu_align_items_horizontally, -1);
     rb_define_method(rb_cMenu, "align_items_vertically", menu_align_items_vertically, -1);
 }


### PR DESCRIPTION
Possible to create a MenuItem from a string.

Usage:
```Ruby
menu = Menu.new
menu.font_item('New Game') { puts 'new game' }
menu.font_item('High Score') { puts 'high score' }
menu.font_item('Exit Game') { puts 'exit game' }
menu.align_items_vertically(25)
add menu, 1
```